### PR TITLE
Add redirect fix for website

### DIFF
--- a/src/netlify.toml
+++ b/src/netlify.toml
@@ -1,0 +1,10 @@
+[[redirects]]
+  from = "http://localhost:3000/"
+  to = "https://my-fixing.netlify.app"
+  status = 200
+  force = true
+  headers = {X-From = "Netlify"}
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Access-Control-Allow-Origin = "*"


### PR DESCRIPTION
This PR adds a redirect on the client side of the application in order to help solve the CORS error.