### PR TITLE
Add loading bar

### DIFF
--- a/src/styling/App.css
+++ b/src/styling/App.css
@@ -59,11 +59,11 @@ table {
   width: 400px;
 }
 
-.loading-message {
+div.loading-message {
 	text-align: center;
 }
 
-.loading-message h2 {
+div.loading-message h2 {
   animation: slide-right 10s;
 }
 

--- a/src/styling/App.css
+++ b/src/styling/App.css
@@ -62,3 +62,19 @@ table {
 .loading-message {
 	text-align: center;
 }
+
+.loading-message h2 {
+  animation: slide-right 10s;
+}
+
+@keyframes slide-right {
+  from {
+    margin-left: -100%;
+    width: 300%; 
+  }
+
+  to {
+    margin-left: 0%;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
This PR adds css animations to the loading message, so that is crawls across the screen for 10 seconds while the projects are loading. This makes it so that the user knows what'a happening with the website, and doesn't think the site is broken.