### PR TITLE
Update styling of videos page

### DIFF
--- a/src/Components/Video.js
+++ b/src/Components/Video.js
@@ -15,10 +15,10 @@ const Video = ({video, projToTry, name, tools}) => {
         <iframe width="420" height="315"
           src={video}>
         </iframe>
-      </section>
       <button onClick={() => projToTry(video)}>Add To My Projects</button>
-      <h3>Required Tools:</h3>
+      </section>
       <section>
+      <h3>Required Tools:</h3>
         <ul className="tools-list">
           {toolsForProj}
         </ul>

--- a/src/Components/Video.js
+++ b/src/Components/Video.js
@@ -12,7 +12,7 @@ const Video = ({video, projToTry, name, tools}) => {
     <div className="video-page-container">
       <section className="video-container">
         <h3>{name}</h3>
-        <iframe width="420" height="315"
+        <iframe width="520" height="415"
           src={video}>
         </iframe>
       <button onClick={() => projToTry(video)}>Add To My Projects</button>

--- a/src/Components/Video.js
+++ b/src/Components/Video.js
@@ -5,7 +5,7 @@ import '../styling/Video.css';
 const Video = ({video, projToTry, name, tools}) => {
   let toolsForProj = tools.map((tool, index) => {
     return (
-      <li key={tool+index}>{tool}</li>
+      <li className="tools-list" key={tool+index}>{tool}</li>
     )
   })
   return ( 
@@ -17,11 +17,13 @@ const Video = ({video, projToTry, name, tools}) => {
         </iframe>
       <button onClick={() => projToTry(video)}>Add To My Projects</button>
       </section>
-      <section>
-      <h3>Required Tools:</h3>
-        <ul className="tools-list">
-          {toolsForProj}
-        </ul>
+      <section className='tools-section'>
+        <details>
+          <summary><h3>Click For Required Tools:</h3></summary>
+          <ul>
+            {toolsForProj}
+          </ul>
+        </details>
       </section>
     </div>
   )

--- a/src/styling/App.css
+++ b/src/styling/App.css
@@ -59,11 +59,11 @@ table {
   width: 400px;
 }
 
-div.loading-message {
+.loading-message {
 	text-align: center;
 }
 
-div.loading-message h2 {
+.loading-message h2 {
   animation: slide-right 10s;
 }
 

--- a/src/styling/NavBar.css
+++ b/src/styling/NavBar.css
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-between;
   background-color: rgb(139, 181, 160);
-  margin-bottom: 8%;
+  margin-bottom: 7%;
   box-shadow: -5px 5px 4px lightgray;
 }
 .page-title {

--- a/src/styling/Video.css
+++ b/src/styling/Video.css
@@ -8,10 +8,11 @@
   color: white;
   flex-direction: column;
   align-items: center;
-  background-color: #28112B;
-  border: 10px solid #453643;
-  box-shadow: 7px 7px 7px #788475;
+  background-color: white;
+  border: 10px solid #624c5f;
+  box-shadow: -7px 7px 7px #788475;
   width: 50%;
+  padding-bottom: 2%;
   margin: 0% 5% 7% 5%;
 }
 
@@ -29,13 +30,17 @@ details {
 .tools-list {
   list-style-type: none;
   font-size: 36px;
+  margin-bottom: 1.5%;
 }
 
 button {
-  height: 7%;
-  width: 30%;
+  height: 5rem;
+  width: 10rem;
   margin-top: 3%;
-  background-color: #7D8491;
+  background-color: rgb(139, 181, 160);
+  border: none;
+  font-weight: bold;
+  font-size: 16px;
 }
 
 @media only screen and (max-width: 800px) {

--- a/src/styling/Video.css
+++ b/src/styling/Video.css
@@ -1,8 +1,6 @@
 .video-page-container {
   display: flex;
-  flex-direction: column;
   height: 75vh;
-  /* align-content: center; */
 }
 
 .video-container {
@@ -14,14 +12,14 @@
   border: 10px solid #453643;
   box-shadow: 7px 7px 7px #788475;
   width: 50%;
-  margin-left: 25%;
+  margin-left: 5%;
 }
 
 button {
   height: 7%;
   width: 30%;
-  margin-left: 35.5%;
-  margin-top: 1%;
+  margin-left: 3%;
+  margin-top: 3%;
   background-color: #7D8491;
 }
 

--- a/src/styling/Video.css
+++ b/src/styling/Video.css
@@ -12,13 +12,28 @@
   border: 10px solid #453643;
   box-shadow: 7px 7px 7px #788475;
   width: 50%;
-  margin-left: 5%;
+  margin: 0% 5% 7% 5%;
+}
+
+summary {
+  background: #453643;
+  width: 40rem;
+  color: white;
+  text-align: center;
+}
+
+details {
+  text-align: center;
+}
+
+.tools-list {
+  list-style-type: none;
+  font-size: 36px;
 }
 
 button {
   height: 7%;
   width: 30%;
-  margin-left: 3%;
   margin-top: 3%;
   background-color: #7D8491;
 }


### PR DESCRIPTION
This PR updates the styling of the videos page. It changes the background color of the video container, and it lightens the border color. In addition, it moves the tools list from being on the bottom of the page to being on the left. In addition, it changes the html element to a details/summary element, where the user can click the tools list open to see the list of the tools. It also moves the video a little bit to the left, instead of being to the center of the page.