### PR TITLE
Re arrange layout

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -62,7 +62,7 @@ const findVideo = (repairs, project) => {
     <div className="App">
       <NavBar />
       <Switch>
-        <Route exact path="/" render={() => <AreasContainer areas={areas} /> } />
+        <Route exact path="/" render={() => <AreasContainer areas={areas} homeRepairs={homeRepairs}/> } />
         <Route exact path="/video/:project" render={( { match }) => findVideo(homeRepairs, match.params.project)} />
         <Route exact path="/tryThis" render={() => listProjectsToTry(homeRepairs, saved)} />
       </Switch>

--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -3,7 +3,6 @@ import AreasContainer from './AreasContainer';
 import  getHomeRepairs  from '../apiCalls';
 import NavBar from './NavBar';
 import Videos from './Videos';
-import Projects from './ProjectsContainer';
 import SavedProjects from './SavedProjects';
 import { Route, Switch } from 'react-router-dom';
 import CatchError from './CatchError';

--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -15,16 +15,6 @@ const App = () =>  {
     let [homeRepairs, setHomeRepairs] = useState([])
     let [loading, setLoading] = useState()
 
-
-
-    useEffect(() => {
-      getHomeRepairs()
-      .then(data => setHomeRepairs(data))
-      .catch(error => setError(error))
-    },[])
-
-    console.log(homeRepairs)
-
   const addToSaved = (projectVid) => {
     if (!saved.includes(projectVid)) {
       setToSaved([...saved, projectVid] )
@@ -52,31 +42,6 @@ const App = () =>  {
       }
     }
   }
-
-const returnProjects = (projects, category) => {
-  let lowerCaseCategory;
-  let lowerCaseArea;
-  if (projects.length > 0) {
-    var filteredProjects = projects.filter(project => {
-      lowerCaseCategory = category.toLowerCase()
-      lowerCaseArea = project.areaOfHome.toLowerCase()
-    if (lowerCaseCategory === lowerCaseArea) {
-      return project
-    }
-    })
-    return (
-    <Projects 
-    filteredProjects={filteredProjects} />
-    )
-  } else {
-    return (
-      <div className='loading-message'>
-        <h2>Building, building, building...</h2>
-        <h2>Thank you for your patience.</h2>
-      </div>
-    )
-  }
-}
 
 const findVideo = (repairs, project) => {
   if (repairs.length > 0) {

--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -63,7 +63,6 @@ const findVideo = (repairs, project) => {
       <NavBar />
       <Switch>
         <Route exact path="/" render={() => <AreasContainer areas={areas} /> } />
-        <Route exact path="/:area/home-improvement-repairs" render={( { match } ) =>  returnProjects(homeRepairs, match.params.area)} />
         <Route exact path="/video/:project" render={( { match }) => findVideo(homeRepairs, match.params.project)} />
         <Route exact path="/tryThis" render={() => listProjectsToTry(homeRepairs, saved)} />
       </Switch>

--- a/src/Components/AreaCards.js
+++ b/src/Components/AreaCards.js
@@ -7,7 +7,7 @@ import bathroom from '../images/bathroom.jpeg';
 import kitchen from '../images/kerstin_kitchen_01.jpeg';
 import miscellaneous from '../images/miscellaneous.jpeg';
 
-const AreaCards = ({homeArea, onClick}) => {
+const AreaCards = ({homeArea, showProjects}) => {
   let images = [bedroom, bathroom, kitchen, miscellaneous]
   let areaPics = images.map(image => {
     if(image.includes(homeArea)) {
@@ -16,7 +16,7 @@ const AreaCards = ({homeArea, onClick}) => {
   })
 
   return (
-      <div onClick={onClick} className='area-card-square'>
+      <div onClick={showProjects(homeArea)} className='area-card-square'>
         <h1 className='home-area'>{homeArea.toUpperCase()}</h1>
         {areaPics}
       </div>

--- a/src/Components/AreaCards.js
+++ b/src/Components/AreaCards.js
@@ -23,6 +23,8 @@ const AreaCards = ({homeArea, onClick}) => {
   )
 }
 
+//So, the function needs to take in the area, as well as set the isClicked to true
+
 
 export default AreaCards;
 

--- a/src/Components/AreaCards.js
+++ b/src/Components/AreaCards.js
@@ -7,7 +7,7 @@ import bathroom from '../images/bathroom.jpeg';
 import kitchen from '../images/kerstin_kitchen_01.jpeg';
 import miscellaneous from '../images/miscellaneous.jpeg';
 
-const AreaCards = ({homeArea}) => {
+const AreaCards = ({homeArea, onClick}) => {
   let images = [bedroom, bathroom, kitchen, miscellaneous]
   let areaPics = images.map(image => {
     if(image.includes(homeArea)) {
@@ -16,12 +16,10 @@ const AreaCards = ({homeArea}) => {
   })
 
   return (
-    <NavLink className="area-card" to={`/${homeArea}/home-improvement-repairs`} >
-      <div className='area-card-square'>
+      <div onClick={onClick} className='area-card-square'>
         <h1 className='home-area'>{homeArea.toUpperCase()}</h1>
         {areaPics}
       </div>
-    </NavLink>
   )
 }
 

--- a/src/Components/AreaCards.js
+++ b/src/Components/AreaCards.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import '../styling/AreaCards.css';
 import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
@@ -7,7 +7,7 @@ import bathroom from '../images/bathroom.jpeg';
 import kitchen from '../images/kerstin_kitchen_01.jpeg';
 import miscellaneous from '../images/miscellaneous.jpeg';
 
-const AreaCards = ({homeArea, showProjects}) => {
+const AreaCards = ({homeArea, setIsClicked, setArea}) => {
   let images = [bedroom, bathroom, kitchen, miscellaneous]
   let areaPics = images.map(image => {
     if(image.includes(homeArea)) {
@@ -15,8 +15,13 @@ const AreaCards = ({homeArea, showProjects}) => {
     } 
   })
 
+  const showProjects = (area) => {
+    setIsClicked(true)
+    setArea(area)
+  }
+
   return (
-      <div onClick={showProjects(homeArea)} className='area-card-square'>
+      <div onClick={(homeArea) => showProjects(homeArea)} className='area-card-square'>
         <h1 className='home-area'>{homeArea.toUpperCase()}</h1>
         {areaPics}
       </div>

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -4,6 +4,32 @@ import AreaCards from './AreaCards';
 import '../styling/Areas.css';
 
 const AreasContainer = ({areas}) => {
+
+  const returnProjects = (projects, category) => {
+    let lowerCaseCategory;
+    let lowerCaseArea;
+    if (projects.length > 0) {
+      var filteredProjects = projects.filter(project => {
+        lowerCaseCategory = category.toLowerCase()
+        lowerCaseArea = project.areaOfHome.toLowerCase()
+      if (lowerCaseCategory === lowerCaseArea) {
+        return project
+      }
+      })
+      return (
+      <Projects 
+      filteredProjects={filteredProjects} />
+      )
+    } else {
+      return (
+        <div className='loading-message'>
+          <h2>Building, building, building...</h2>
+          <h2>Thank you for your patience.</h2>
+        </div>
+      )
+    }
+  }
+  
   let allAreas = areas.map(area => {
     return (
       <AreaCards 

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -1,9 +1,18 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import AreaCards from './AreaCards';
 import '../styling/Areas.css';
 
 const AreasContainer = ({areas}) => {
+
+  let [homeRepairs, setHomeRepairs] = useState([])
+  let [isClicked, setIsClicked] = useState(false)
+
+  useEffect(() => {
+    getHomeRepairs()
+    .then(data => setHomeRepairs(data))
+    .catch(error => setError(error))
+  },[])
 
   const returnProjects = (projects, category) => {
     let lowerCaseCategory;
@@ -29,12 +38,14 @@ const AreasContainer = ({areas}) => {
       )
     }
   }
-  
+
   let allAreas = areas.map(area => {
     return (
       <AreaCards 
         key={area}
-        homeArea={area}/>
+        homeArea={area}
+        onClick={() => setIsClicked(true)}
+        />
     )
   })
   return (

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -3,16 +3,10 @@ import PropTypes from 'prop-types';
 import AreaCards from './AreaCards';
 import '../styling/Areas.css';
 
-const AreasContainer = ({areas}) => {
+const AreasContainer = ({homeRepairs, areas}) => {
 
-  let [homeRepairs, setHomeRepairs] = useState([])
   let [isClicked, setIsClicked] = useState(false)
-
-  useEffect(() => {
-    getHomeRepairs()
-    .then(data => setHomeRepairs(data))
-    .catch(error => setError(error))
-  },[])
+  let [area, setArea] = useState('')
 
   const returnProjects = (projects, category) => {
     let lowerCaseCategory;
@@ -44,7 +38,9 @@ const AreasContainer = ({areas}) => {
       <AreaCards 
         key={area}
         homeArea={area}
-        onClick={() => setIsClicked(true)}
+        onClick={() => {
+          setIsClicked(true)
+        }}
         />
     )
   })
@@ -53,7 +49,7 @@ const AreasContainer = ({areas}) => {
       <h1>Pick an area of your home where you have a DIY project, or where something needs fixing.</h1>
       <div className="area-cards-container">
       {allAreas}
-      {isClicked && returnProjects()}
+      {isClicked && returnProjects(homeRepairs, area)}
     </div>
     </section>
   )

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -53,6 +53,7 @@ const AreasContainer = ({areas}) => {
       <h1>Pick an area of your home where you have a DIY project, or where something needs fixing.</h1>
       <div className="area-cards-container">
       {allAreas}
+      {isClicked && returnProjects()}
     </div>
     </section>
   )

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -30,8 +30,7 @@ const AreasContainer = ({homeRepairs, areas}) => {
   }
 
   const showProjects = (area) => {
-    setIsClicked(true)
-    setArea(area)
+    setIsClicked()
   }
 
   let allAreas = areas.map(area => {
@@ -39,7 +38,8 @@ const AreasContainer = ({homeRepairs, areas}) => {
       <AreaCards 
         key={area}
         homeArea={area}
-        showProjects={showProjects}
+        setIsClicked={setIsClicked}
+        setArea={setArea}
         />
     )
   })

--- a/src/Components/AreasContainer.js
+++ b/src/Components/AreasContainer.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import AreaCards from './AreaCards';
+import Projects from './ProjectsContainer';
 import '../styling/Areas.css';
 
 const AreasContainer = ({homeRepairs, areas}) => {
@@ -9,18 +10,13 @@ const AreasContainer = ({homeRepairs, areas}) => {
   let [area, setArea] = useState('')
 
   const returnProjects = (projects, category) => {
-    let lowerCaseCategory;
-    let lowerCaseArea;
     if (projects.length > 0) {
       var filteredProjects = projects.filter(project => {
-        lowerCaseCategory = category.toLowerCase()
-        lowerCaseArea = project.areaOfHome.toLowerCase()
-      if (lowerCaseCategory === lowerCaseArea) {
+      if (category === project.areaOfHome) {
         return project
-      }
-      })
+      }})
       return (
-      <Projects 
+      <Projects
       filteredProjects={filteredProjects} />
       )
     } else {
@@ -33,14 +29,17 @@ const AreasContainer = ({homeRepairs, areas}) => {
     }
   }
 
+  const showProjects = (area) => {
+    setIsClicked(true)
+    setArea(area)
+  }
+
   let allAreas = areas.map(area => {
     return (
       <AreaCards 
         key={area}
         homeArea={area}
-        onClick={() => {
-          setIsClicked(true)
-        }}
+        showProjects={showProjects}
         />
     )
   })

--- a/src/styling/App.css
+++ b/src/styling/App.css
@@ -53,16 +53,6 @@ table {
 	text-align: center;
 }
 
-.content {
-  text-align: center;
-}
-
-.hero-image {
-  background-image: ur('../images/kerstin_kitchen_01.jpeg');
-  height: 400px;
-  width: 400px;
-}
-
 /* .loading-message {
 	text-align: center;
   overflow: hidden;
@@ -74,10 +64,11 @@ table {
   animation: slide-right 10s forwards;
 } */
 
-.loading-message {
+.loading-message h2 {
   width: 100px;
   height: 100px;
   background: plum;
+  color: blue;
   transform: translateX(100%);
   position: fixed;
   -webkit-animation: anim 3.5s 1;


### PR DESCRIPTION
This PR re-arranges the layout of the font-page to subtract a view change for the user. It did this by moving the return project from the app file to the area container file. It re-added the useEffect, so that the projects could be fetched. It also moved the area list to the area container. In addition, it added a function that could set two states in the area component, so that it would use one function, instead of two.