### PR TITLE
Update saved projects design

### DIFF
--- a/src/Components/App.js
+++ b/src/Components/App.js
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import AreasContainer from './AreasContainer';
-import  getHomeRepairs  from '../apiCalls';
+import getHomeRepairs  from '../apiCalls';
 import NavBar from './NavBar';
-import Videos from './Videos';
 import SavedProjects from './SavedProjects';
 import { Route, Switch } from 'react-router-dom';
 import CatchError from './CatchError';
+import VideosContainer from './VideosContainer';
 
 const App = () =>  {
     let areas =  ['kitchen', 'bathroom', 'bedroom', 'misc']
@@ -48,12 +48,11 @@ const App = () =>  {
     }
   }
 
-
 const findVideo = (repairs, project) => {
   if (repairs.length > 0) {
   let foundVideo = repairs.find(repair => repair.project === project)
     return (
-      <Videos toTry={addToSaved} repairVideo={foundVideo} />
+      <VideosContainer toTry={addToSaved} repairVideo={foundVideo} />
     )
   }
 }

--- a/src/Components/AreaCards.js
+++ b/src/Components/AreaCards.js
@@ -16,7 +16,6 @@ const AreaCards = ({homeArea, setArea}) => {
   })
 
   const showProjects = (area) => {
-    console.log(area)
     setArea(area)
   }
 

--- a/src/Components/SavedProjects.js
+++ b/src/Components/SavedProjects.js
@@ -1,16 +1,17 @@
 import React from 'react';
-import Project from './Project';
 import PropTypes from 'prop-types';
+import Video from './Video';
 
 const SavedProjects = ({category}) => {
+  console.log('a project', category)
   let savedProjects = category.map(category => {
+    console.log('in the map', category)
     return (
-      <Project
+      <Video 
         key={category.id}
-        id={category.id}
+        video={category.videos}
         name={category.project}
-        tools={category.toolsNeeded}
-        />
+      />
     )
   })
   return (

--- a/src/Components/Video.js
+++ b/src/Components/Video.js
@@ -18,7 +18,7 @@ const Video = ({video, projToTry, name, tools}) => {
         <iframe width="520" height="415"
           src={video}>
         </iframe>
-      <button onClick={() => projToTry(video)}>Add To My Projects</button>
+      {tools && <button onClick={() => projToTry(video)}>Add To My Projects</button>}
       </section>
       {tools && <section className='tools-section'>
         <details>

--- a/src/Components/Video.js
+++ b/src/Components/Video.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types';
 import '../styling/Video.css';
 
 const Video = ({video, projToTry, name, tools}) => {
-  let toolsForProj = tools.map((tool, index) => {
-    return (
-      <li className="tools-list" key={tool+index}>{tool}</li>
-    )
-  })
+  let toolsForProj;
+  if(tools) {
+    toolsForProj = tools.map((tool, index) => {
+      return (
+        <li className="tools-list" key={tool+index}>{tool}</li>
+      )
+    }) 
+  }
   return ( 
     <div className="video-page-container">
       <section className="video-container">
@@ -17,14 +20,14 @@ const Video = ({video, projToTry, name, tools}) => {
         </iframe>
       <button onClick={() => projToTry(video)}>Add To My Projects</button>
       </section>
-      <section className='tools-section'>
+      {tools && <section className='tools-section'>
         <details>
           <summary><h3>Click For Required Tools:</h3></summary>
           <ul>
             {toolsForProj}
           </ul>
         </details>
-      </section>
+      </section>}
     </div>
   )
 }

--- a/src/Components/VideosContainer.js
+++ b/src/Components/VideosContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Video from './Video'
 
-const Videos = ({repairVideo, toTry}) => {
+const VideosContainer = ({repairVideo, toTry}) => {
   return (
     <Video 
       key={repairVideo.id}
@@ -14,9 +14,9 @@ const Videos = ({repairVideo, toTry}) => {
     )
   }
 
-export default Videos
+export default VideosContainer;
 
-Videos.propType = {
+VideosContainer.propType = {
   repairVideo: PropTypes.object.isRequired,
   toTry: PropTypes.func.isRequired
 }

--- a/src/styling/Video.css
+++ b/src/styling/Video.css
@@ -15,6 +15,10 @@
   margin: 0% 5% 7% 5%;
 }
 
+.video-container h3 {
+  color: black;
+}
+
 summary {
   background: #453643;
   width: 40rem;


### PR DESCRIPTION
This PR updates the design of the saved projects page. Originally, it was a list of titles, but now it shows the videos of the projects that a person would want to save for later. It re-uses the video component, but modifies it based on whether or not tools are being passed in as props. In addition, it changes the color of the title to make it black and readable.